### PR TITLE
Add scan API with supabase

### DIFF
--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import supabase from '@/lib/supabase';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { url, user_id } = await request.json();
+
+    if (!url || !user_id) {
+      return NextResponse.json(
+        { error: 'Missing url or user_id' },
+        { status: 400 }
+      );
+    }
+
+    if (!supabase) {
+      return NextResponse.json(
+        { error: 'Supabase not configured' },
+        { status: 500 }
+      );
+    }
+
+    // Fake scan result
+    const payload = {
+      url,
+      score: Math.floor(Math.random() * 100),
+      suggestions: ['Use a cookie banner', 'Update privacy policy'],
+      user_id,
+    };
+
+    const { error, data } = await supabase
+      .from('scans')
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: err.message || 'Something went wrong' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -120,6 +120,11 @@ const env = {
     secretKey: process.env.STRIPE_SECRET_KEY,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
   },
+
+  supabase: {
+    url: process.env.SUPABASE_URL,
+    anonKey: process.env.SUPABASE_ANON_KEY,
+  },
 };
 
 export default env;

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import env from './env';
+
+let supabase: SupabaseClient | null = null;
+
+if (env.supabase.url && env.supabase.anonKey) {
+  supabase = createClient(env.supabase.url, env.supabase.anonKey);
+}
+
+export default supabase;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@retracedhq/logs-viewer": "2.10.1",
         "@retracedhq/retraced": "0.7.23",
         "@sentry/nextjs": "9.24.0",
+        "@supabase/supabase-js": "^2.39.7",
         "@tailwindcss/typography": "0.5.16",
         "bcryptjs": "3.0.2",
         "classnames": "2.5.1",
@@ -8220,6 +8221,102 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/gotrue-js": {
+      "version": "2.62.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+      "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+      "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.39.7",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.39.7.tgz",
+      "integrity": "sha512-1vxsX10Uhc2b+Dv9pRjBjHfqmw2N2h1PyTg9LEfICR3x2xwE24By1MGCjDZuzDKH5OeHCsf4it6K8KRluAAEXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/functions-js": "2.1.5",
+        "@supabase/gotrue-js": "2.62.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -8643,6 +8740,12 @@
       "dependencies": {
         "@types/pg": "*"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@retracedhq/logs-viewer": "2.10.1",
     "@retracedhq/retraced": "0.7.23",
     "@sentry/nextjs": "9.24.0",
+    "@supabase/supabase-js": "^2.39.7",
     "@tailwindcss/typography": "0.5.16",
     "bcryptjs": "3.0.2",
     "classnames": "2.5.1",


### PR DESCRIPTION
## Summary
- create `/api/scan/route.ts` for storing scan data
- setup Supabase client
- expose SUPABASE variables in env config
- add `@supabase/supabase-js` dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684167a017a4832f8d1f8f39bfac863d