### PR TITLE
Add HTTPS validation for webhooks

### DIFF
--- a/pages/api/teams/[slug]/webhooks/index.ts
+++ b/pages/api/teams/[slug]/webhooks/index.ts
@@ -65,7 +65,9 @@ const handlePOST = async (req: NextApiRequest, res: NextApiResponse) => {
   );
   const app = await findOrCreateApp(teamMember.team.name, teamMember.team.id);
 
-  // TODO: The endpoint URL must be HTTPS.
+  if (!url.startsWith('https://')) {
+    throw new ApiError(400, 'Webhook URL must start with https://');
+  }
 
   const data: EndpointIn = {
     description: name,

--- a/tests/e2e/settings/webhook.spec.ts
+++ b/tests/e2e/settings/webhook.spec.ts
@@ -1,0 +1,45 @@
+import { test as base, expect } from '@playwright/test';
+import { user, team } from '../support/helper';
+import { LoginPage, WebhookPage } from '../support/fixtures';
+
+type WebhookFixture = {
+  loginPage: LoginPage;
+  webhookPage: WebhookPage;
+};
+
+const test = base.extend<WebhookFixture>({
+  loginPage: async ({ page }, use) => {
+    const loginPage = new LoginPage(page);
+    await use(loginPage);
+  },
+  webhookPage: async ({ page }, use) => {
+    const webhookPage = new WebhookPage(page, team.slug);
+    await use(webhookPage);
+  },
+});
+
+test.beforeEach(async ({ loginPage }) => {
+  await loginPage.goto();
+  await loginPage.credentialLogin(user.email, user.password);
+  await loginPage.loggedInCheck(team.slug);
+});
+
+// Verify that insecure webhook URLs are rejected
+test('Should not allow webhook creation with http URL', async ({ webhookPage }) => {
+  await webhookPage.goto();
+  await webhookPage.openCreateModal();
+  await webhookPage.fillDescription('Test Webhook');
+  await webhookPage.fillEndpoint('http://example.com/webhook');
+  await webhookPage.selectFirstEvent();
+
+  const [response] = await Promise.all([
+    webhookPage.page.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/teams/${team.slug}/webhooks`) &&
+        resp.request().method() === 'POST'
+    ),
+    webhookPage.submit(),
+  ]);
+
+  expect(response.status()).toBe(400);
+});

--- a/tests/e2e/support/fixtures/index.ts
+++ b/tests/e2e/support/fixtures/index.ts
@@ -6,3 +6,4 @@ export * from './member-page';
 export * from './security-page';
 export * from './settings-page';
 export * from './sso-page';
+export * from './webhook-page';

--- a/tests/e2e/support/fixtures/webhook-page.ts
+++ b/tests/e2e/support/fixtures/webhook-page.ts
@@ -1,0 +1,45 @@
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class WebhookPage {
+  private readonly heading: Locator;
+  private readonly addWebhookButton: Locator;
+  private readonly descriptionInput: Locator;
+  private readonly endpointInput: Locator;
+  private readonly createButton: Locator;
+
+  constructor(public readonly page: Page, public readonly teamSlug: string) {
+    this.heading = this.page.getByRole('heading', { name: 'Webhooks' });
+    this.addWebhookButton = this.page.getByRole('button', { name: 'Add Webhook' });
+    this.descriptionInput = this.page.getByPlaceholder('Description of what this endpoint is used for.');
+    this.endpointInput = this.page.getByPlaceholder('https://api.example.com/svix-webhooks');
+    this.createButton = this.page.getByRole('dialog').getByRole('button', { name: 'Create Webhook' });
+  }
+
+  async goto() {
+    await this.page.goto(`/teams/${this.teamSlug}/webhooks`);
+    await this.page.waitForURL(`/teams/${this.teamSlug}/webhooks`);
+    await expect(this.heading).toBeVisible();
+  }
+
+  async openCreateModal() {
+    await this.addWebhookButton.click();
+    await expect(this.page.getByRole('heading', { name: 'Create Webhook' })).toBeVisible();
+  }
+
+  async fillDescription(text: string) {
+    await this.descriptionInput.fill(text);
+  }
+
+  async fillEndpoint(text: string) {
+    await this.endpointInput.fill(text);
+  }
+
+  async selectFirstEvent() {
+    await this.page.getByLabel('member.created').check();
+  }
+
+  async submit() {
+    await this.createButton.click();
+  }
+}


### PR DESCRIPTION
## Summary
- enforce HTTPS for webhook URLs in API
- add a WebhookPage test fixture
- add e2e test that refuses insecure webhook URLs

## Testing
- `npm run test`
- `npx playwright test tests/e2e/settings/webhook.spec.ts --project=chromium` *(fails: Could not find a production build)*


------
https://chatgpt.com/codex/tasks/task_e_6841714d274c832fb8b1fc093c532ce7