### PR TITLE
Implement group event handling

### DIFF
--- a/__tests__/lib/dsyncEvents.spec.ts
+++ b/__tests__/lib/dsyncEvents.spec.ts
@@ -1,0 +1,57 @@
+jest.mock('models/group');
+jest.mock('models/team', () => ({
+  addTeamMember: jest.fn(),
+  removeTeamMember: jest.fn(),
+}));
+jest.mock('models/user', () => ({
+  deleteUser: jest.fn(),
+  getUser: jest.fn(),
+  updateUser: jest.fn(),
+  upsertUser: jest.fn(),
+}));
+jest.mock('models/teamMember', () => ({
+  countTeamMembers: jest.fn(),
+}));
+
+import { handleEvents } from '../../lib/jackson/dsyncEvents';
+import * as groupModel from '../../models/group';
+
+const createGroup = groupModel.createGroup as jest.Mock;
+const updateGroup = groupModel.updateGroup as jest.Mock;
+const deleteGroup = groupModel.deleteGroup as jest.Mock;
+
+describe('Lib - dsyncEvents group handling', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should create group on group.created', async () => {
+    await handleEvents({
+      event: 'group.created',
+      tenant: 'team1',
+      data: { id: 'g1', name: 'Group', raw: { a: 1 } },
+    } as any);
+
+    expect(createGroup).toHaveBeenCalledWith({ id: 'g1', name: 'Group', teamId: 'team1', raw: { a: 1 } });
+  });
+
+  it('should update group on group.updated', async () => {
+    await handleEvents({
+      event: 'group.updated',
+      tenant: 'team1',
+      data: { id: 'g1', name: 'New Name', raw: { b: 2 } },
+    } as any);
+
+    expect(updateGroup).toHaveBeenCalledWith({ where: { id: 'g1' }, data: { name: 'New Name', raw: { b: 2 } } });
+  });
+
+  it('should delete group on group.deleted', async () => {
+    await handleEvents({
+      event: 'group.deleted',
+      tenant: 'team1',
+      data: { id: 'g1' },
+    } as any);
+
+    expect(deleteGroup).toHaveBeenCalledWith('g1');
+  });
+});

--- a/lib/jackson/dsyncEvents.ts
+++ b/lib/jackson/dsyncEvents.ts
@@ -3,94 +3,69 @@ import { Role } from '@prisma/client';
 import { addTeamMember, removeTeamMember } from 'models/team';
 import { deleteUser, getUser, updateUser, upsertUser } from 'models/user';
 import { countTeamMembers } from 'models/teamMember';
+import { createGroup, deleteGroup, updateGroup } from 'models/group';
 
 // Handle SCIM events
 export const handleEvents = async (event: DirectorySyncEvent) => {
   const { event: action, tenant: teamId, data } = event;
 
-  // Currently we only handle the user events
-  // TODO: Handle group events
-  if (!('email' in data)) {
-    return;
-  }
-
-  const { email, first_name, last_name, active } = data;
-  const name = `${first_name} ${last_name}`;
-
-  // User has been added
-  if (action === 'user.created') {
-    const user = await upsertUser({
-      where: {
-        email,
-      },
-      update: {
-        name,
-      },
-      create: {
-        email,
-        name,
-      },
-    });
-
-    await addTeamMember(teamId, user.id, Role.MEMBER);
-  }
-
-  // User has been updated
-  else if (action === 'user.updated') {
-    const user = await getUser({ email });
-
-    if (!user) {
+  if (action.startsWith('user.')) {
+    if (!('email' in data)) {
       return;
     }
 
-    // Deactivation of user by removing them from the team
-    if (active === false) {
-      await removeTeamMember(teamId, user.id);
+    const { email, first_name, last_name, active } = data;
+    const name = `${first_name} ${last_name}`;
 
-      const otherTeamsCount = await countTeamMembers({
-        where: {
-          userId: user.id,
-        },
+    if (action === 'user.created') {
+      const user = await upsertUser({
+        where: { email },
+        update: { name },
+        create: { email, name },
       });
 
+      await addTeamMember(teamId, user.id, Role.MEMBER);
+    } else if (action === 'user.updated') {
+      const user = await getUser({ email });
+      if (!user) {
+        return;
+      }
+
+      if (active === false) {
+        await removeTeamMember(teamId, user.id);
+        const otherTeamsCount = await countTeamMembers({
+          where: { userId: user.id },
+        });
+        if (otherTeamsCount === 0) {
+          await deleteUser({ email: user.email });
+        }
+        return;
+      }
+
+      await updateUser({ where: { email }, data: { name } });
+      await addTeamMember(teamId, user.id, Role.MEMBER);
+    } else if (action === 'user.deleted') {
+      const user = await getUser({ email });
+      if (!user) {
+        return;
+      }
+
+      await removeTeamMember(teamId, user.id);
+      const otherTeamsCount = await countTeamMembers({
+        where: { userId: user.id },
+      });
       if (otherTeamsCount === 0) {
         await deleteUser({ email: user.email });
       }
-
-      return;
     }
-
-    await updateUser({
-      where: {
-        email,
-      },
-      data: {
-        name,
-      },
-    });
-
-    // Reactivation of user by adding them back to the team
-    await addTeamMember(teamId, user.id, Role.MEMBER);
-  }
-
-  // User has been removed
-  else if (action === 'user.deleted') {
-    const user = await getUser({ email });
-
-    if (!user) {
-      return;
-    }
-
-    await removeTeamMember(teamId, user.id);
-
-    const otherTeamsCount = await countTeamMembers({
-      where: {
-        userId: user.id,
-      },
-    });
-
-    if (otherTeamsCount === 0) {
-      await deleteUser({ email: user.email });
-    }
+  } else if (action === 'group.created') {
+    const { id, name, raw } = data as any;
+    await createGroup({ id, name, teamId, raw });
+  } else if (action === 'group.updated') {
+    const { id, name, raw } = data as any;
+    await updateGroup({ where: { id }, data: { name, raw } });
+  } else if (action === 'group.deleted') {
+    const { id } = data as any;
+    await deleteGroup(id);
   }
 };

--- a/models/group.ts
+++ b/models/group.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@/lib/prisma';
+
+export const createGroup = async (data: { id: string; name: string; teamId: string; raw?: any }) => {
+  return await prisma.group.create({ data });
+};
+
+export const updateGroup = async ({ where, data }: { where: { id: string }; data: { name?: string; raw?: any } }) => {
+  return await prisma.group.update({ where, data });
+};
+
+export const deleteGroup = async (id: string) => {
+  return await prisma.group.delete({ where: { id } });
+};
+
+export const upsertGroup = async ({ where, create, update }: { where: { id: string }; create: { id: string; name: string; teamId: string; raw?: any }; update: { name?: string; raw?: any } }) => {
+  return await prisma.group.upsert({ where, create, update });
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,8 +82,22 @@ model Team {
   members         TeamMember[]
   invitations     Invitation[]
   apiKeys         ApiKey[]
+  groups          Group[]
 
   @@index([billingId])
+}
+
+model Group {
+  id        String   @id
+  teamId    String
+  name      String
+  raw       Json?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
+
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@index([teamId])
 }
 
 model TeamMember {


### PR DESCRIPTION
## Summary
- support group events in Directory Sync handler
- model groups in Prisma schema
- add group model helpers
- test group event handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841714e1cc8832f8077916aec866f63