### PR TITLE
Add API route tests

### DIFF
--- a/__tests__/api/pdf.spec.ts
+++ b/__tests__/api/pdf.spec.ts
@@ -1,0 +1,12 @@
+/** @jest-environment node */
+import { GET } from '../../app/api/pdf/route';
+
+describe('API - pdf', () => {
+  it('returns a pdf response', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/pdf');
+    const buffer = Buffer.from(await res.arrayBuffer());
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/api/scan.spec.ts
+++ b/__tests__/api/scan.spec.ts
@@ -1,0 +1,61 @@
+
+/** @jest-environment node */
+import puppeteer from 'puppeteer';
+
+jest.mock('puppeteer');
+
+const supabaseMock = {
+  from: jest.fn(() => ({
+    insert: jest.fn(() => ({
+      select: jest.fn(() => ({
+        single: jest.fn().mockResolvedValue({ data: { id: 1 }, error: null }),
+      })),
+    })),
+  })),
+};
+
+jest.mock('../../lib/supabase', () => ({ __esModule: true, default: supabaseMock }));
+
+describe('API - scan', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 on success', async () => {
+    const browserMock = {
+      newPage: jest.fn().mockResolvedValue({
+        goto: jest.fn(),
+        evaluate: jest.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(true),
+        $: jest.fn().mockResolvedValue(null),
+      }),
+      close: jest.fn(),
+    };
+    (puppeteer.launch as jest.Mock).mockResolvedValue(browserMock);
+
+    const { POST } = await import('../../app/api/scan/route');
+    const req = {
+      json: () => Promise.resolve({ url: 'http://test.com', user_id: '1', pro: false }),
+    } as any;
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data).toBeDefined();
+    expect(supabaseMock.from).toHaveBeenCalledWith('scans');
+  });
+
+  it('returns 400 when missing params', async () => {
+    const { POST } = await import('../../app/api/scan/route');
+    const req = { json: () => Promise.resolve({ url: '', user_id: '' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when supabase not configured', async () => {
+    jest.resetModules();
+    jest.doMock('../../lib/supabase', () => ({ __esModule: true, default: null }));
+    const { POST } = await import('../../app/api/scan/route');
+    const req = { json: () => Promise.resolve({ url: 'http://test.com', user_id: '1' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for PDF route
- add tests for scan route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418f6e02d4832fa6e83f2cf54942f9