### PR TITLE
Add docker-compose Next.js service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,13 @@ cp .env.example .env
 #### 5. Create a database (Optional)
 
 To make the process of installing dependencies easier, we offer a `docker-compose.yml` with a Postgres container.
+It also defines a service for running the Next.js app.
 
 ```bash
 docker-compose up -d
 ```
+
+This command starts the database and launches the app at `http://localhost:4002`.
 
 #### 6. Set up database schema
 
@@ -139,6 +142,8 @@ In a development environment:
 ```bash
 npm run dev
 ```
+
+If you started the app with Docker Compose, it is already running at `http://localhost:4002`.
 
 #### 8. Start the Prisma Studio
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,16 @@ services:
       POSTGRES_DB: saas-starter-kit
     ports:
       - 5432:5432
+
+  web:
+    image: node:18
+    working_dir: /usr/src/app
+    volumes:
+      - .:/usr/src/app
+    command: sh -c "npm install && npm run dev"
+    env_file:
+      - .env
+    ports:
+      - 4002:4002
+    depends_on:
+      - db


### PR DESCRIPTION
## Summary
- add a `web` service in `docker-compose.yml` that runs the Next.js dev server
- document Docker Compose usage in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418f6f2ab4832f8dfa5b92814d37cc