### PR TITLE
Add openaiApiKey to env

### DIFF
--- a/app/api/scan/route.ts
+++ b/app/api/scan/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import supabase from '@/lib/supabase';
 import puppeteer from 'puppeteer';
 import OpenAI from 'openai';
+import env from '@/lib/env';
 
 async function analyzeUrl(url: string) {
   const browser = await puppeteer.launch({
@@ -35,8 +36,8 @@ async function analyzeUrl(url: string) {
 }
 
 async function gptSuggestions(result: any) {
-  if (!process.env.OPENAI_API_KEY) return [] as string[];
-  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  if (!env.openaiApiKey) return [] as string[];
+  const client = new OpenAI({ apiKey: env.openaiApiKey });
   const completion = await client.chat.completions.create({
     model: 'gpt-4o',
     messages: [

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -126,6 +126,8 @@ const env = {
     anonKey: process.env.SUPABASE_ANON_KEY,
     serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
   },
+
+  openaiApiKey: process.env.OPENAI_API_KEY,
 };
 
 export default env;


### PR DESCRIPTION
## Summary
- include OPENAI_API_KEY in lib/env.ts
- use env.openaiApiKey in scan route

## Testing
- `npm run test-all`

------
https://chatgpt.com/codex/tasks/task_e_68418f6fc148832fa77ca4548d478239