### PR TITLE
Implement scans pages and components

### DIFF
--- a/components/scan/ScanForm.tsx
+++ b/components/scan/ScanForm.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { useSession } from 'next-auth/react';
+import { Button, Input } from 'react-daisyui';
+import toast from 'react-hot-toast';
+import { useRouter } from 'next/router';
+import { defaultHeaders } from '@/lib/common';
+import type { ApiResponse } from 'types';
+
+const ScanForm = () => {
+  const { t } = useTranslation('common');
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [url, setUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const response = await fetch('/api/scan', {
+      method: 'POST',
+      headers: defaultHeaders,
+      body: JSON.stringify({ url, user_id: session?.user.id }),
+    });
+    const json = (await response.json()) as ApiResponse<{ id: string }>;
+    setLoading(false);
+    if (!response.ok) {
+      toast.error(json.error.message);
+      return;
+    }
+    const id = (json.data as any)?.id;
+    if (id) {
+      router.push(`/scans/${id}`);
+    } else {
+      toast.success(t('successfully-updated'));
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 max-w-lg">
+      <Input
+        type="url"
+        placeholder="https://example.com"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        className="w-full"
+        required
+      />
+      <Button type="submit" color="primary" loading={loading} disabled={!url}>
+        {t('new-scan')}
+      </Button>
+    </form>
+  );
+};
+
+export default ScanForm;

--- a/components/scan/ScanList.tsx
+++ b/components/scan/ScanList.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
+import useScans from 'hooks/useScans';
+import { WithLoadingAndError } from '@/components/shared';
+import { Table } from '@/components/shared/table/Table';
+
+const ScanList = () => {
+  const { t } = useTranslation('common');
+  const { scans, isLoading, isError } = useScans();
+
+  return (
+    <WithLoadingAndError isLoading={isLoading} error={isError}>
+      <div className="space-y-3">
+        <h2 className="text-xl font-medium leading-none tracking-tight">
+          {t('scan-history')}
+        </h2>
+        <Table
+          cols={[t('url'), t('created'), t('score'), t('actions')]}
+          body={
+            scans
+              ? scans.map((scan) => ({
+                  id: scan.id,
+                  cells: [
+                    { wrap: true, text: scan.url },
+                    { wrap: true, text: new Date(scan.created_at).toLocaleDateString() },
+                    { wrap: true, text: String(scan.score) },
+                    {
+                      element: (
+                        <Link href={`/scans/${scan.id}`} className="link">
+                          {t('view')}
+                        </Link>
+                      ),
+                    },
+                  ],
+                }))
+              : []
+          }
+          noMoreResults={scans?.length === 0}
+        />
+      </div>
+    </WithLoadingAndError>
+  );
+};
+
+export default ScanList;

--- a/components/scan/ScanResult.tsx
+++ b/components/scan/ScanResult.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'next-i18next';
+
+interface Props {
+  scan: {
+    url: string;
+    score: number;
+    suggestions: string[];
+  };
+}
+
+const ScanResult = ({ scan }: Props) => {
+  const { t } = useTranslation('common');
+
+  if (!scan) return null;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-medium leading-none tracking-tight">{scan.url}</h2>
+      <p>
+        {t('score')}: {scan.score}
+      </p>
+      <div>
+        <h3 className="font-semibold">{t('gdpr-suggestions')}</h3>
+        <ul className="list-disc pl-5 space-y-1">
+          {scan.suggestions?.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default ScanResult;

--- a/components/scan/index.ts
+++ b/components/scan/index.ts
@@ -1,0 +1,3 @@
+export { default as ScanForm } from './ScanForm';
+export { default as ScanList } from './ScanList';
+export { default as ScanResult } from './ScanResult';

--- a/components/shared/shell/UserNavigation.tsx
+++ b/components/shared/shell/UserNavigation.tsx
@@ -2,6 +2,7 @@ import {
   RectangleStackIcon,
   ShieldCheckIcon,
   UserCircleIcon,
+  DocumentMagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
 import { useTranslation } from 'next-i18next';
 import NavigationItems from './NavigationItems';
@@ -16,6 +17,12 @@ const UserNavigation = ({ activePathname }: NavigationProps) => {
       href: '/teams',
       icon: RectangleStackIcon,
       active: activePathname === '/teams',
+    },
+    {
+      name: t('scans'),
+      href: '/scans',
+      icon: DocumentMagnifyingGlassIcon,
+      active: activePathname?.startsWith('/scans'),
     },
     {
       name: t('account'),

--- a/hooks/useScan.ts
+++ b/hooks/useScan.ts
@@ -1,0 +1,16 @@
+import fetcher from '@/lib/fetcher';
+import useSWR from 'swr';
+import type { ApiResponse } from 'types';
+import { Scan } from 'models/scan';
+
+const useScan = (id?: string) => {
+  const { data, error, isLoading } = useSWR<ApiResponse<Scan>>(id ? `/api/scans/${id}` : null, fetcher);
+
+  return {
+    isLoading,
+    isError: error,
+    scan: data?.data,
+  };
+};
+
+export default useScan;

--- a/hooks/useScans.ts
+++ b/hooks/useScans.ts
@@ -1,0 +1,22 @@
+import fetcher from '@/lib/fetcher';
+import useSWR, { mutate } from 'swr';
+import type { ApiResponse } from 'types';
+import { Scan } from 'models/scan';
+
+const useScans = () => {
+  const url = '/api/scans';
+  const { data, error, isLoading } = useSWR<ApiResponse<Scan[]>>(url, fetcher);
+
+  const mutateScans = async () => {
+    mutate(url);
+  };
+
+  return {
+    isLoading,
+    isError: error,
+    scans: data?.data,
+    mutateScans,
+  };
+};
+
+export default useScans;

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -247,4 +247,10 @@
   "unable-to-find": "We're unable to find out what's happening! We suggest you to",
   "try-again-later": "or visit here later.",
   "multiple-sso-teams": "User belongs to multiple teams with SSO enabled. Please enter your team slug to get started."
+  "scans": "Scans",
+  "new-scan": "New scan",
+  "scan-history": "Scan history",
+  "gdpr-suggestions": "GDPR suggestions",
+  "view": "View",
+  "score": "Score"
 }

--- a/models/scan.ts
+++ b/models/scan.ts
@@ -1,0 +1,36 @@
+import supabase from '@/lib/supabase';
+
+export interface Scan {
+  id: string;
+  url: string;
+  user_id: string;
+  cookieBannerFound: boolean;
+  privacyPolicyFound: boolean;
+  formDetected: boolean;
+  score: number;
+  suggestions: string[];
+  pro: boolean;
+  created_at: string;
+}
+
+export const getUserScans = async (userId: string): Promise<Scan[]> => {
+  if (!supabase) throw new Error('Supabase not configured');
+  const { data, error } = await supabase
+    .from('scans')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return (data as Scan[]) || [];
+};
+
+export const getScanById = async (id: string): Promise<Scan | null> => {
+  if (!supabase) throw new Error('Supabase not configured');
+  const { data, error } = await supabase
+    .from('scans')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as Scan) || null;
+};

--- a/pages/api/scans/[id].ts
+++ b/pages/api/scans/[id].ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getScanById } from 'models/scan';
+import { getCurrentUser } from 'models/user';
+import { ApiError } from '@/lib/errors';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    switch (req.method) {
+      case 'GET':
+        await handleGET(req, res);
+        break;
+      default:
+        res.setHeader('Allow', 'GET');
+        res.status(405).json({ error: { message: `Method ${req.method} Not Allowed` } });
+    }
+  } catch (error: any) {
+    const message = error.message || 'Something went wrong';
+    const status = error.status || 500;
+    res.status(status).json({ error: { message } });
+  }
+}
+
+const handleGET = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { id } = req.query as { id: string };
+  const user = await getCurrentUser(req, res);
+  const scan = await getScanById(id);
+  if (!scan || scan.user_id !== user.id) {
+    throw new ApiError(404, 'Scan not found');
+  }
+  res.status(200).json({ data: scan });
+};

--- a/pages/api/scans/index.ts
+++ b/pages/api/scans/index.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getUserScans } from 'models/scan';
+import { getCurrentUser } from 'models/user';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    switch (req.method) {
+      case 'GET':
+        await handleGET(req, res);
+        break;
+      default:
+        res.setHeader('Allow', 'GET');
+        res.status(405).json({ error: { message: `Method ${req.method} Not Allowed` } });
+    }
+  } catch (error: any) {
+    const message = error.message || 'Something went wrong';
+    const status = error.status || 500;
+    res.status(status).json({ error: { message } });
+  }
+}
+
+const handleGET = async (req: NextApiRequest, res: NextApiResponse) => {
+  const user = await getCurrentUser(req, res);
+  const scans = await getUserScans(user.id);
+  res.status(200).json({ data: scans });
+};

--- a/pages/scans/[id].tsx
+++ b/pages/scans/[id].tsx
@@ -1,0 +1,37 @@
+import { ScanResult } from '@/components/scan';
+import { Error, Loading } from '@/components/shared';
+import { GetServerSidePropsContext } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { useRouter } from 'next/router';
+import useScan from 'hooks/useScan';
+import type { NextPageWithLayout } from 'types';
+
+const ScanDetails: NextPageWithLayout = () => {
+  const { query, isReady } = useRouter();
+  const id = isReady ? (query.id as string) : undefined;
+  const { scan, isLoading, isError } = useScan(id);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    return <Error message={isError.message} />;
+  }
+
+  if (!scan) {
+    return <Error message="Scan not found" />;
+  }
+
+  return <ScanResult scan={scan} />;
+};
+
+export async function getStaticProps({ locale }: GetServerSidePropsContext) {
+  return {
+    props: {
+      ...(locale ? await serverSideTranslations(locale, ['common']) : {}),
+    },
+  };
+}
+
+export default ScanDetails;

--- a/pages/scans/index.tsx
+++ b/pages/scans/index.tsx
@@ -1,0 +1,18 @@
+import { ScanList } from '@/components/scan';
+import { GetServerSidePropsContext } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import type { NextPageWithLayout } from 'types';
+
+const ScansPage: NextPageWithLayout = () => {
+  return <ScanList />;
+};
+
+export async function getStaticProps({ locale }: GetServerSidePropsContext) {
+  return {
+    props: {
+      ...(locale ? await serverSideTranslations(locale, ['common']) : {}),
+    },
+  };
+}
+
+export default ScansPage;

--- a/pages/scans/new.tsx
+++ b/pages/scans/new.tsx
@@ -1,0 +1,18 @@
+import { ScanForm } from '@/components/scan';
+import { GetServerSidePropsContext } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import type { NextPageWithLayout } from 'types';
+
+const NewScanPage: NextPageWithLayout = () => {
+  return <ScanForm />;
+};
+
+export async function getStaticProps({ locale }: GetServerSidePropsContext) {
+  return {
+    props: {
+      ...(locale ? await serverSideTranslations(locale, ['common']) : {}),
+    },
+  };
+}
+
+export default NewScanPage;


### PR DESCRIPTION
## Summary
- add React components for scanning
- fetch scans from Supabase via new API endpoints
- list scans and show results
- add navigation link for new `Scans` section
- add English translations for new texts

## Testing
- `npm test`
- `npm run check-types`
- `npm run check-lint`


------
https://chatgpt.com/codex/tasks/task_e_684198631488832f956536add5349612