### PR TITLE
Add Privacy & Terms pages

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -246,5 +246,13 @@
   "internal-server-error": "Internal Server Error !",
   "unable-to-find": "We're unable to find out what's happening! We suggest you to",
   "try-again-later": "or visit here later.",
-  "multiple-sso-teams": "User belongs to multiple teams with SSO enabled. Please enter your team slug to get started."
+  "multiple-sso-teams": "User belongs to multiple teams with SSO enabled. Please enter your team slug to get started.",
+  "scans": "Scans",
+  "new-scan": "New scan",
+  "scan-history": "Scan history",
+  "gdpr-suggestions": "GDPR suggestions",
+  "view": "View",
+  "score": "Score",
+  "privacy-policy": "Privacy Policy",
+  "terms-of-service": "Terms of Service"
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "next-i18next": "15.4.2",
     "nodemailer": "6.10.1",
     "openai": "^5.1.0",
+    "pdf-lib": "1.17.1",
     "puppeteer": "^24.10.0",
     "react": "18.3.1",
     "react-daisyui": "5.0.5",
@@ -66,8 +67,7 @@
     "svix": "1.66.0",
     "swr": "2.3.3",
     "yup": "1.6.1",
-    "zod": "3.25.46",
-    "pdf-lib": "1.17.1"
+    "zod": "3.25.46"
   },
   "devDependencies": {
     "@faker-js/faker": "9.8.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -67,6 +67,15 @@ const Home: NextPageWithLayout = () => {
         <PricingSection />
         <div className="divider"></div>
         <FAQSection />
+        <footer className="py-4 text-center text-sm">
+          <Link href="/privacy" className="link link-hover">
+            {t('privacy-policy')}
+          </Link>
+          <span className="mx-1">|</span>
+          <Link href="/terms" className="link link-hover">
+            {t('terms-of-service')}
+          </Link>
+        </footer>
       </div>
     </>
   );

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,53 @@
+import { GetServerSidePropsContext } from 'next';
+import Head from 'next/head';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { useTranslation } from 'next-i18next';
+import type { NextPageWithLayout } from 'types';
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+
+const Privacy: NextPageWithLayout = () => {
+  const { t } = useTranslation('common');
+
+  return (
+    <>
+      <Head>
+        <title>{t('privacy-policy')}</title>
+      </Head>
+      <div className="container mx-auto px-4 py-10 prose">
+        <h1>{t('privacy-policy')}</h1>
+        <p>
+          GDPRcheck360 is committed to protecting your privacy. We process
+          personal data solely to deliver and improve our services. Your
+          information is never shared with third parties except as required by
+          law.
+        </p>
+        <p>
+          We collect only the data necessary to operate the platform and store
+          it securely. If you have any questions about how we handle your data,
+          please contact us at{' '}
+          <Link href="mailto:support@gdprcheck360.com">
+            support@gdprcheck360.com
+          </Link>
+          .
+        </p>
+      </div>
+    </>
+  );
+};
+
+export const getServerSideProps = async ({
+  locale,
+}: GetServerSidePropsContext) => {
+  return {
+    props: {
+      ...(locale ? await serverSideTranslations(locale, ['common']) : {}),
+    },
+  };
+};
+
+Privacy.getLayout = function getLayout(page: ReactElement) {
+  return <>{page}</>;
+};
+
+export default Privacy;

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -1,0 +1,47 @@
+import { GetServerSidePropsContext } from 'next';
+import Head from 'next/head';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { useTranslation } from 'next-i18next';
+import type { NextPageWithLayout } from 'types';
+import type { ReactElement } from 'react';
+
+const Terms: NextPageWithLayout = () => {
+  const { t } = useTranslation('common');
+
+  return (
+    <>
+      <Head>
+        <title>{t('terms-of-service')}</title>
+      </Head>
+      <div className="container mx-auto px-4 py-10 prose">
+        <h1>{t('terms-of-service')}</h1>
+        <p>
+          By using GDPRcheck360 you agree to comply with these terms of service.
+          You are responsible for ensuring that your use of the platform is in
+          accordance with all applicable laws and regulations.
+        </p>
+        <p>
+          We reserve the right to suspend or terminate access for activities
+          that violate these terms. Your continued use of the service indicates
+          acceptance of any updates to these terms.
+        </p>
+      </div>
+    </>
+  );
+};
+
+export const getServerSideProps = async ({
+  locale,
+}: GetServerSidePropsContext) => {
+  return {
+    props: {
+      ...(locale ? await serverSideTranslations(locale, ['common']) : {}),
+    },
+  };
+};
+
+Terms.getLayout = function getLayout(page: ReactElement) {
+  return <>{page}</>;
+};
+
+export default Terms;


### PR DESCRIPTION
## Summary
- add Privacy Policy & Terms of Service pages
- link to those pages from the landing page footer
- include translation keys for the new pages
- resolve merge conflict in locale file

## Testing
- `npx prettier -w pages/index.tsx pages/privacy.tsx pages/terms.tsx locales/en/common.json`


------
https://chatgpt.com/codex/tasks/task_e_684198677a9c832f820b334d8bbbc1dc