### PR TITLE
Add Playwright test for scan page

### DIFF
--- a/tests/e2e/scan/scan.spec.ts
+++ b/tests/e2e/scan/scan.spec.ts
@@ -1,0 +1,29 @@
+import { test as base } from '@playwright/test';
+import { user, team } from '../support/helper';
+import { LoginPage, ScanPage } from '../support/fixtures';
+
+type ScanFixture = {
+  loginPage: LoginPage;
+  scanPage: ScanPage;
+};
+
+const test = base.extend<ScanFixture>({
+  loginPage: async ({ page }, use) => {
+    const loginPage = new LoginPage(page);
+    await use(loginPage);
+  },
+  scanPage: async ({ page }, use) => {
+    const scanPage = new ScanPage(page);
+    await use(scanPage);
+  },
+});
+
+test('Should scan a website and show results', async ({ loginPage, scanPage }) => {
+  await loginPage.goto();
+  await loginPage.credentialLogin(user.email, user.password);
+  await loginPage.loggedInCheck(team.slug);
+
+  await scanPage.goto();
+  await scanPage.scan('https://example.com');
+  await scanPage.resultsVisible();
+});

--- a/tests/e2e/support/fixtures/index.ts
+++ b/tests/e2e/support/fixtures/index.ts
@@ -7,3 +7,4 @@ export * from './security-page';
 export * from './settings-page';
 export * from './sso-page';
 export * from './webhook-page';
+export * from './scan-page';

--- a/tests/e2e/support/fixtures/scan-page.ts
+++ b/tests/e2e/support/fixtures/scan-page.ts
@@ -1,0 +1,29 @@
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class ScanPage {
+  private readonly urlInput: Locator;
+  private readonly scanButton: Locator;
+  private readonly resultsHeading: Locator;
+
+  constructor(public readonly page: Page) {
+    this.urlInput = this.page.getByPlaceholder('https://example.com');
+    this.scanButton = this.page.getByRole('button', { name: 'Scan' });
+    this.resultsHeading = this.page.getByRole('heading', { name: /Results/i });
+  }
+
+  async goto() {
+    await this.page.goto('/scan');
+    await this.page.waitForURL('/scan');
+    await expect(this.urlInput).toBeVisible();
+  }
+
+  async scan(url: string) {
+    await this.urlInput.fill(url);
+    await this.scanButton.click();
+  }
+
+  async resultsVisible() {
+    await expect(this.resultsHeading).toBeVisible();
+  }
+}


### PR DESCRIPTION
## Summary
- add ScanPage fixture for e2e tests
- implement scan page spec
- export the fixture from support index

## Testing
- `npm test`
- `npx playwright test tests/e2e/scan/scan.spec.ts --project=chromium --workers=1` *(fails: Could not start Next.js server)*

------
https://chatgpt.com/codex/tasks/task_e_68419875abac832fae832eb9512c9936