### PR TITLE
Update privacy and terms text with translations

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -254,5 +254,9 @@
   "view": "View",
   "score": "Score",
   "privacy-policy": "Privacy Policy",
-  "terms-of-service": "Terms of Service"
+  "terms-of-service": "Terms of Service",
+  "privacy-paragraph-1": "GDPRcheck360 is committed to protecting your privacy. We process personal data solely to deliver and improve our services. Your information is never shared with third parties except as required by law.",
+  "privacy-paragraph-2": "We collect only the data necessary to operate the platform and store it securely. If you have any questions about how we handle your data, please contact us at <mailtoLink>support@gdprcheck360.com</mailtoLink>.",
+  "terms-paragraph-1": "By using GDPRcheck360 you agree to comply with these terms of service. You are responsible for ensuring that your use of the platform is in accordance with all applicable laws and regulations.",
+  "terms-paragraph-2": "We reserve the right to suspend or terminate access for activities that violate these terms. Your continued use of the service indicates acceptance of any updates to these terms."
 }

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,7 +1,7 @@
 import { GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { useTranslation } from 'next-i18next';
+import { Trans, useTranslation } from 'next-i18next';
 import type { NextPageWithLayout } from 'types';
 import type { ReactElement } from 'react';
 import Link from 'next/link';
@@ -16,21 +16,13 @@ const Privacy: NextPageWithLayout = () => {
       </Head>
       <div className="container mx-auto px-4 py-10 prose">
         <h1>{t('privacy-policy')}</h1>
-        <p>
-          GDPRcheck360 is committed to protecting your privacy. We process
-          personal data solely to deliver and improve our services. Your
-          information is never shared with third parties except as required by
-          law.
-        </p>
-        <p>
-          We collect only the data necessary to operate the platform and store
-          it securely. If you have any questions about how we handle your data,
-          please contact us at{' '}
-          <Link href="mailto:support@gdprcheck360.com">
-            support@gdprcheck360.com
-          </Link>
-          .
-        </p>
+        <p>{t('privacy-paragraph-1')}</p>
+        <Trans
+          i18nKey="privacy-paragraph-2"
+          components={{
+            mailtoLink: <Link href="mailto:support@gdprcheck360.com" />,
+          }}
+        />
       </div>
     </>
   );

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -15,16 +15,8 @@ const Terms: NextPageWithLayout = () => {
       </Head>
       <div className="container mx-auto px-4 py-10 prose">
         <h1>{t('terms-of-service')}</h1>
-        <p>
-          By using GDPRcheck360 you agree to comply with these terms of service.
-          You are responsible for ensuring that your use of the platform is in
-          accordance with all applicable laws and regulations.
-        </p>
-        <p>
-          We reserve the right to suspend or terminate access for activities
-          that violate these terms. Your continued use of the service indicates
-          acceptance of any updates to these terms.
-        </p>
+        <p>{t('terms-paragraph-1')}</p>
+        <p>{t('terms-paragraph-2')}</p>
       </div>
     </>
   );

--- a/tests/e2e/scan/scan.spec.ts
+++ b/tests/e2e/scan/scan.spec.ts
@@ -10,10 +10,12 @@ type ScanFixture = {
 const test = base.extend<ScanFixture>({
   loginPage: async ({ page }, use) => {
     const loginPage = new LoginPage(page);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     await use(loginPage);
   },
   scanPage: async ({ page }, use) => {
     const scanPage = new ScanPage(page);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     await use(scanPage);
   },
 });


### PR DESCRIPTION
## Summary
- add i18n entries for privacy and terms paragraphs
- render translated privacy text using `Trans`
- hook up translated terms text
- fix ESLint error in scan test

## Testing
- `npm run check-locale`
- `npm run check-lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d9739ec8832f9b3626753db57ddd