### PR TITLE
Fix translation imports for error pages

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { AccountLayout } from '@/components/layouts';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'next-i18next';
 import { GetServerSidePropsContext } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Link from 'next/link';

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { AccountLayout } from '@/components/layouts';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'next-i18next';
 import { GetServerSidePropsContext } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import router from 'next/router';


### PR DESCRIPTION
## Summary
- update 404 and 500 pages to import `useTranslation` from **next-i18next**
- run tests and locale checks

## Testing
- `npm test`
- `npm run check-locale`

------
https://chatgpt.com/codex/tasks/task_e_6841d9754dc8832f8593afb83527f1cf