### PR TITLE
Fix missing getStaticPaths for dynamic page

### DIFF
--- a/pages/scans/[id].tsx
+++ b/pages/scans/[id].tsx
@@ -34,4 +34,11 @@ export async function getStaticProps({ locale }: GetServerSidePropsContext) {
   };
 }
 
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  };
+}
+
 export default ScanDetails;


### PR DESCRIPTION
## Summary
- add `getStaticPaths` to `scans/[id]` page so dynamic SSG works

## Testing
- `npm run build` *(fails: could not complete Next.js build in container)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee780378832f80ce95847714792e